### PR TITLE
Documentation improvements

### DIFF
--- a/lib/MooX/Log/Any.pm
+++ b/lib/MooX/Log/Any.pm
@@ -34,6 +34,19 @@ MooX::Log::Any - Role to add Log::Any
 
 version 0.004004
 
+=head1 SYNOPSIS;
+
+    package MyApp;
+    use Moo;
+    
+    with 'MooX::Log::Any';
+    
+    sub something {
+        my ($self) = @_;
+        $self->log->debug("started bar");    ### logs with default class catergory "MyApp"
+        $self->log->error("started bar");    ### logs with default class catergory "MyApp"
+    }
+
 =head1 DESCRIPTION
 
 A logging role building a very lightweight wrapper to L<Log::Any> for use with your L<Moo> or L<Moose> classes.
@@ -62,19 +75,6 @@ The logger needs to be setup before using the logger, which could happen in the 
     $myclass->log->info("In my class"); # Access the log of the object
     $myclass->dummy;                    # Will log "Dummy log entry"
 
-=head1 SYNOPSIS;
-
-    package MyApp;
-    use Moo;
-    
-    with 'MooX::Log::Any';
-    
-    sub something {
-        my ($self) = @_;
-        $self->log->debug("started bar");    ### logs with default class catergory "MyApp"
-        $self->log->error("started bar");    ### logs with default class catergory "MyApp"
-    }
-
 =head1 ACCESSORS
 
 =head2 log
@@ -86,7 +86,7 @@ roles/systems like L<MooseX::Log::LogDispatch> this can be thought of as a commo
   package MyApp::View::JSON;
 
   extends 'MyApp::View';
-  with 'MooseX:Log::Log4perl';
+  with 'MooX:Log::Any';
 
   sub bar {
     $self->logger->info("Everything fine so far");    # logs a info message

--- a/lib/MooX/Log/Any.pm
+++ b/lib/MooX/Log/Any.pm
@@ -75,6 +75,35 @@ The logger needs to be setup before using the logger, which could happen in the 
     $myclass->log->info("In my class"); # Access the log of the object
     $myclass->dummy;                    # Will log "Dummy log entry"
 
+A really advanced usage would allow configuring externally and avoid leaking memory when using this in classes instantiated several times ... (logging isn't limited to Apps):
+
+    package MyRole;
+
+    use Class::Load('load_class'); # see (1)
+    use Moo::Role;
+    with 'MooX::Log::Any';
+    has log_adapter => is => "ro" => required => 1 => trigger => 1;
+    has log_guard   => is => "rw" => init_arg => undef;
+
+    sub _trigger_log_guard {
+	my ($self, $opts) = @_;
+	my $guard;
+	load_class("Log::Any::Adapter")->set({lexically => \$guard}, @{$opts}); # see (2)
+	$self->log_guard($guard);
+    }
+
+=over 4
+
+=item 1
+
+See L<Moo::Role/"CLEANING UP IMPORTS">
+
+=item 2
+
+Can be varied or improved using L<Params::Util/_ARRAY0> or L<Params::Util/_HASH0> ...
+
+=back
+
 =head1 ACCESSORS
 
 =head2 log


### PR DESCRIPTION
Adding an extra example showing how to re-use MX::L::A in roles and/or configure it externally and/or avoid mem-leaks (https://github.com/cazador481/MooX-Log-Any/issues/10, https://github.com/preaction/Log-Any/issues/25)